### PR TITLE
Patch 1

### DIFF
--- a/template.inx
+++ b/template.inx
@@ -11,6 +11,7 @@
 			<param name="param1" type="int"   min="3"    max="1200"    _gui-text="A numeric integer value(3..1200)">12</param>
 			<param name="param2" type="float" min="0.1"  max="1000.0"  precision="5"  _gui-text="A floating value">1.0</param>
 			<param name="param3" _gui-text="A Choice" type="optiongroup">
+				<!-- underscores indicate translatability -->
 				<_option value="choice1">Label for Choice 1</_option>
 				<_option value="choice2">Label for Choice 2</_option>
 				<_option value="choice3">Label for Choice 3</_option>

--- a/template.py
+++ b/template.py
@@ -13,7 +13,7 @@ from math import cos, sin, radians
 
 __version__ = '0.1'
 
-
+inkex.localize()
 
 ### Your helper functions go here
 def points_to_svgd(p, close=True):
@@ -123,7 +123,11 @@ class Myextension(inkex.Effect): # choose a better name
                                      dest="active_tab", default='',
                                      help="Active tab. Not used now.")
         
-
+    def getUnittouu(self, param):
+        try:
+            return inkex.unittouu(param)
+        except AttributeError:
+            return self.unittouu(param)
     
     def add_text(self, node, text, position, text_height=12):
         """ Create and insert a single line of text into the svg under node.
@@ -146,8 +150,8 @@ class Myextension(inkex.Effect): # choose a better name
               everything in inkscape is expected to be in 90dpi pixel units
         """
         # namedView = self.document.getroot().find(inkex.addNS('namedview', 'sodipodi'))
-        # doc_units = inkex.uutounit(1.0, namedView.get(inkex.addNS('document-units', 'inkscape')))
-        dialog_units = inkex.uutounit(1.0, self.options.units)
+        # doc_units = self.getUnittouu(1.0, namedView.get(inkex.addNS('document-units', 'inkscape')))
+        dialog_units = self.getUnittouu(1.0, self.options.units)
         unit_factor = 1.0 / dialog_units
         return unit_factor
 
@@ -161,6 +165,12 @@ class Myextension(inkex.Effect): # choose a better name
               iterate through them
             - Turn on other visual features e.g. cross, rack, annotations, etc
         """
+        
+        # check for correct number of selected objects and return a translatable errormessage to the user
+        if len(self.options.ids) != 2:
+            inkex.errormsg(_("This extension requires two selected objects."))
+            exit()  
+        
         path_stroke = '#000000'  # might expose one day
         path_fill   = 'none'     # no fill - just a line
         path_stroke_width  = 0.6 # might expose one day


### PR DESCRIPTION
Hi @Neon22,

I've updated the extension template to be compatible with Inkscape 0.91, while maintaining compatibility with previous versions (see http://wiki.inkscape.org/wiki/index.php/Release_notes/0.91#Units:_Breaking_change) and added a translatable error message and a hint about the meaning of the underscores in the inx file to the mix.

We might include a link to this repo on the Inkscape website, or even upload the files there to the page that explains how to write extensions:
https://inkscape.org/en/develop/extensions/ if you agree.
